### PR TITLE
remove react dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "matrix-js-sdk": "^26.1.0",
     "pg": "^8.11.2",
     "prom-client": "^14.2.0",
-    "react": "^18.2.0",
     "reflect-metadata": "^0.1.13",
     "request": "^2.88.2",
     "typeorm": "^0.3.17"
@@ -85,7 +84,6 @@
     "@types/express": "^4.17.13",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.16",
-    "@types/react": "^18",
     "@types/request": "^2.48.8",
     "@types/supertest": "^2.0.12",
     "eslint-plugin-security": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,11 +2237,6 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.0.tgz#efcbd41937f9ae7434c714ab698604822d890759"
   integrity sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==
 
-"@types/prop-types@*":
-  version "15.7.12"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.12.tgz#12bb1e2be27293c1406acb6af1c3f3a1481d98c6"
-  integrity sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==
-
 "@types/qs@*":
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
@@ -2251,14 +2246,6 @@
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
-
-"@types/react@^18":
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.1.tgz#fed43985caa834a2084d002e4771e15dfcbdbe8e"
-  integrity sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
 
 "@types/readdir-glob@*":
   version "1.1.1"
@@ -3420,11 +3407,6 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
-
-csstype@^3.0.2:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
-  integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
 dashdash@^1.12.0:
   version "1.14.1"


### PR DESCRIPTION
Previously, the tests failed:
```
 FAIL  src/dripper/DripRequestHandler.spec.ts
  ● Test suite failed to run

    Cannot find module 'react' from 'node_modules/react-i18next/dist/commonjs/Trans.js'
```

`yarn` install showed that react wasn't installed so we added the dep manually.

```
(base) ➜  polkadot-testnet-faucet git:(procaptcha) ✗ yarn            
yarn install v1.22.19
info No lockfile found.
[1/4] Resolving packages...
warning request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning request > uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
warning request > har-validator@5.1.5: this library is no longer supported
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > @polkadot/x-randomvalues@12.5.1" has unmet peer dependency "@polkadot/wasm-util@*".
warning "@prosopo/server > @polkadot/keyring@12.3.2" has incorrect peer dependency "@polkadot/util@12.3.2".
warning "@prosopo/server > @polkadot/keyring@12.3.2" has incorrect peer dependency "@polkadot/util-crypto@12.3.2".
warning "@prosopo/server > @prosopo/types > @prosopo/common > react-i18next@11.18.6" has unmet peer dependency "react@>= 16.8.0".
warning " > prettier-plugin-svelte@3.0.3" has unmet peer dependency "svelte@^3.2.0 || ^4.0.0-next.0".
[4/4] Building fresh packages...
success Saved lockfile.
$ yarn generate:types
yarn run v1.22.19
$ echo "declare const schema: $(cat env.faucet.config.json); export default schema;" > env.faucet.config.json.d.ts
Done in 0.06s.
$ ts-patch install -s
Done in 132.41s.
```

`warning "@prosopo/server > @prosopo/types > @prosopo/common > react-i18next@11.18.6" has unmet peer dependency `
Seems like it is fixed now as this warning doesn't appear on install.